### PR TITLE
Some fixes for issues experienced on my machine

### DIFF
--- a/cron-gui-launcher.bash
+++ b/cron-gui-launcher.bash
@@ -1,43 +1,72 @@
 #!/bin/bash
 
 # [0.] Create log file. Use "$2" to leave a description within the name.
-if [ -z "${2+x}" ]; then DESCRIPTION=""; else DESCRIPTION="-$2"; fi
+if [ -z "${2+x}" ]; 
+  then DESCRIPTION=""; 
+else 
+  DESCRIPTION="-$2"; 
+fi
+
 LOG="/tmp/$USER-cron-gui-launcher$DESCRIPTION.log"
 printf '\n%s\n\n\nDetected environment variables:\n\n' "$(date +%Y-%m-%d_%H:%M:%S)" > "$LOG"
 
 # [1.] Get the value of the $DISPLAY variable for the current user. Unset it just in case this is a `ssh -X` connection
 unset DISPLAY; timeout=0
 while [ -z "$DISPLAY" ]; do
-        DISPLAY=$(w "$USER" | awk 'NF > 7 && $2 ~ /tty[0-9]+/ {print $3; exit}' 2>/dev/null)
-        if [ "$DISPLAY" == "" ]; then sleep 60; else export DISPLAY=$DISPLAY; fi
-        ((timeout++)); if [ "$timeout" -eq "$3" ]; then printf "Timeout: %s\n" "$timeout" >> "$LOG"; exit 1; fi
+  DISPLAY=$(w "$USER" | awk 'NF > 7 && $2 ~ /tty[0-9]+/ {print $3; exit}' 2>/dev/null)
+  if [ -z "$DISPLAY" ]; 
+    then sleep 60; 
+  else 
+    export DISPLAY=$DISPLAY; 
+  fi
+  ((timeout++)); 
+  if test ! -z "$3" && [ "$timeout" -eq "$3" ]; then 
+    printf "Timeout: %s\n" "$timeout" >> "$LOG"; 
+    exit 1; 
+  fi
 done; printf 'DISPLAY=%s\n' "$DISPLAY" >> "$LOG"
 
 # [->2.] Get certain envvar value ("$1") from any "/proc/$ProcessNumber/environ" file ("$2")
 get_environ(){
-	EnvVar=$(sed -zne "s/^$1=//p" "/proc/$2/environ" 2>/dev/null); printf "%s" "$EnvVar";
+  envsrc=/proc/$2/environ
+  if test -r $envsrc; then
+    # discard nulls in source file
+    envvars=$(tr -d '\000' < /proc/$2/environ)
+  	EnvVar=$(sed -zne "s/^$1=//p" "$envvars" 2>/dev/null); 
+    printf "%s" "$EnvVar";
+  else
+    EnvVar=
+  fi
 }
 
 # [->3.] Get the most frequent value from an array - https://stackoverflow.com/a/43440769/6543935
 get_frequent(){
-        awk 'BEGIN{ FS=" " } { for(i=1;i<=NF;i++) print $i }' | \
-        awk '{ n=++hsh[$1]; if(n>max_occ){ max_occ=n; what=$1 } else if(n==max_occ){ if(what>$1) what=$1 } } END{ print what }'
+  awk 'BEGIN{ FS=" " } { for(i=1;i<=NF;i++) print $i }' | \
+  awk '{ n=++hsh[$1]; if(n>max_occ){ max_occ=n; what=$1 } else if(n==max_occ){ if(what>$1) what=$1 } } END{ print what }'
 }
 
 # [->5.] Get the conten ot the current-desktop-session's environment file as an array, then export each line
 export_environ(){
-        printf '\n\nExported environment (source file /proc/%s/environ):\n\n' "$1" >> "$LOG"
-        EnvVarList=$(cat -e "/proc/$1/environ" | sed 's/\^@/\n/g')
-	for EnvVar in $EnvVarList; do echo "export $EnvVar" >> "$LOG"; export "$EnvVar"; done
+  printf '\n\nExported environment (source file /proc/%s/environ):\n\n' "$1" >> "$LOG"
+  EnvVarList=$(cat -e "/proc/$1/environ" | sed 's/\^@/\n/g')
+  IFSBAK=$IFS
+  IFS=$'\n'
+	for EnvVar in $EnvVarList; do 
+    echo "export $EnvVar" >> "$LOG"; 
+    export "$EnvVar"; 
+  done
+  IFS=$IFSBAK
 }
 
 # [->6.] Fragmentation of the list of the input commands (input variable "$1"), use ` && ` as separator, then execute each one
 execute_input_commands(){
-        printf "%s" "$1" | awk 'BEGIN{ FS=" && "; print "\nInput command list:" } {for(i=1;i<=NF;i++) system("echo \"Command: " $i "\"") system("nohup " $i " >/dev/null 2>&1 &")}' >> "$LOG"
+  printf "%s" "$1" | awk 'BEGIN{ FS=" && "; print "\nInput command list:" } {for(i=1;i<=NF;i++) system("echo \"Command: " $i "\"") system("nohup " $i " >/dev/null 2>&1 &")}' >> "$LOG"
 }
 
 # [2.] Get the value of $XDG_CURRENT_DESKTOP from each "/proc/$ProcessNumber/environ" file - create an array.
-for PN in $(pgrep -U "$UID"); do XDG_CURRENT_DESKTOP+=$(get_environ "XDG_CURRENT_DESKTOP" "$PN"; echo " "); done
+for PN in $(pgrep -U "$UID"); do 
+  XDG_CURRENT_DESKTOP+=$(get_environ "XDG_CURRENT_DESKTOP" "$PN"; echo " "); 
+done
 
 # [3.] Get the name of the current Desktop Environment
 XDG_CURRENT_DESKTOP=$(echo -e "${XDG_CURRENT_DESKTOP[@]}" | get_frequent)


### PR DESCRIPTION
fix: allow for environment variables with spaces in them
        - eg gentoo's CONFIG_PROTECT_* variables
fix: remove script warnings due to reading null chars from
        /proc/*/environ sources
fix: don't attempt to compare timeout with non-existant timeout
        value via numeric comparison (causes bash warning)